### PR TITLE
修正分享链接时如果缩略图本来就足够小时的问题

### DIFF
--- a/src/org/zywx/wbpalmstar/plugin/uexweixin/EuexWeChat.java
+++ b/src/org/zywx/wbpalmstar/plugin/uexweixin/EuexWeChat.java
@@ -1108,7 +1108,8 @@ public class EuexWeChat extends EUExBase {
 		}
 		Bitmap thumbBmp = Bitmap.createScaledBitmap(bmp, THUMB_SIZE,
 				THUMB_SIZE, true);
-		if (bmp != null) {
+			
+		if (bmp != null && bmp != thumbBmp) {
 			bmp.recycle();
 		}
 		return thumbBmp;

--- a/uexWeiXin/info.xml
+++ b/uexWeiXin/info.xml
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <uexplugins>
-    <plugin uexName="uexWeiXin" version="3.1.27" build = "27">
-        <info>27:修复分享回调时应用奔溃退出的问题</info>
+    <plugin uexName="uexWeiXin" version="3.1.28" build = "28">
+        <info>28:修正链接分享时图片本来已经比较小不需要缩略导致的问题</info>
+        <build>27:修复分享回调时应用奔溃退出的问题</build>
         <build>26:修改回调方法</build>
         <build>25:新添加微信登陆功能</build>
         <build>24:修改分享文本、分享图片、分享链接回调接口参数</build>


### PR DESCRIPTION
修正分享链接时,传入的缩略图图片本来就足够小的时候会报：can`t compress a recycled bitmap 的错误。
